### PR TITLE
Refactor: Rename groups to tags

### DIFF
--- a/api/src/main/java/lateralview/net/attm2xapiv2/common/Constants.java
+++ b/api/src/main/java/lateralview/net/attm2xapiv2/common/Constants.java
@@ -10,7 +10,7 @@ public class Constants {
     //Device calls
     public static final String DEVICE_SEARCH_PUBLIC_CATALOG = API_BASE_URL.concat("/devices/catalog");
     public static final String DEVICE_SEARCH_CATALOG = API_BASE_URL.concat("/devices");
-    public static final String DEVICE_LIST_GROUPS = API_BASE_URL.concat("/devices/groups");
+    public static final String DEVICE_LIST_TAGS = API_BASE_URL.concat("/devices/tags");
     public static final String DEVICE_CREATE = API_BASE_URL.concat("/devices");
     public static final String DEVICE_UPDATE_DETAILS = API_BASE_URL.concat("/devices/%s");
     public static final String DEVICE_VIEW_DETAILS = API_BASE_URL.concat("/devices/%s");

--- a/api/src/main/java/lateralview/net/attm2xapiv2/model/Device.java
+++ b/api/src/main/java/lateralview/net/attm2xapiv2/model/Device.java
@@ -18,7 +18,7 @@ public class Device {
 
     public static final int REQUEST_CODE_SEARCH_PUBLIC_CATALOG = 1001;
     public static final int REQUEST_CODE_SEARCH_DEVICES = 1002;
-    public static final int REQUEST_CODE_LIST_DEVICE_GROUP = 1003;
+    public static final int REQUEST_CODE_LIST_DEVICE_TAG = 1003;
     public static final int REQUEST_CODE_CREATE_DEVICE = 1004;
     public static final int REQUEST_CODE_DEVICE_DETAILS = 1005;
     public static final int REQUEST_CODE_DEVICE_LOCATION = 1006;
@@ -63,13 +63,13 @@ public class Device {
         );
     }
 
-    public static final void listDeviceGroups(Context context, ResponseListener listener){
+    public static final void listDeviceTags(Context context, ResponseListener listener){
         JsonRequest.makeGetRequest(
                 context,
-                Constants.DEVICE_LIST_GROUPS,
+                Constants.DEVICE_LIST_TAGS,
                 null,
                 listener,
-                REQUEST_CODE_LIST_DEVICE_GROUP
+                REQUEST_CODE_LIST_DEVICE_TAG
         );
     }
 

--- a/app/src/main/java/lateralview/net/m2xapiv2exampleapp/activities/DeviceActivity.java
+++ b/app/src/main/java/lateralview/net/m2xapiv2exampleapp/activities/DeviceActivity.java
@@ -62,8 +62,8 @@ public class DeviceActivity extends Activity implements ResponseListener {
         Device.searchDevices(DeviceActivity.this, params, this);
     }
 
-    public void listGroups(View view) {
-        Device.listDeviceGroups(DeviceActivity.this, this);
+    public void listTags(View view) {
+        Device.listDeviceTags(DeviceActivity.this, this);
     }
 
     public void createDevice(View view) {

--- a/app/src/main/res/layout/activity_device.xml
+++ b/app/src/main/res/layout/activity_device.xml
@@ -26,8 +26,8 @@
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="List Groups"
-            android:onClick="listGroups"/>
+            android:text="List Tags"
+            android:onClick="listTags"/>
 
         <Button
             android:layout_width="wrap_content"


### PR DESCRIPTION
The groups concept has been deprecated in favor of [tags](https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags).

Update the examples in this application to reflect said change.